### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/681/27/85668127.geojson
+++ b/data/856/681/27/85668127.geojson
@@ -125,7 +125,7 @@
     "qs:source":"Natural Earth",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "uscensus-display-terrestrial-zoom-10"
+        "uscensus"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
@@ -156,6 +156,9 @@
         "qs_pg:id":1263411
     },
     "wof:country":"AS",
+    "wof:geom_alt":[
+        "uscensus-display-terrestrial-zoom-10"
+    ],
     "wof:geomhash":"514c8de74e2a022f84d38176132023ea",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1566588580,
+    "wof:lastmodified":1582358653,
     "wof:name":"Eastern",
     "wof:parent_id":85632697,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.