### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/583/029/9/1125830299.geojson
+++ b/data/112/583/029/9/1125830299.geojson
@@ -22,11 +22,20 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ceb_x_preferred":[
+        "\u2018Aoa"
+    ],
+    "name:deu_x_preferred":[
+        "'Aoa"
+    ],
     "name:eng_x_preferred":[
         "'Aoa"
     ],
     "name:fas_x_preferred":[
         "\u0622\u0648\u0622"
+    ],
+    "name:fra_x_preferred":[
+        "'Aoa"
     ],
     "name:ita_x_preferred":[
         "'Aoa"
@@ -39,6 +48,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0410\u043e\u0430"
+    ],
+    "name:swe_x_preferred":[
+        "\u2018Aoa"
     ],
     "qs_pg:aaroncc":"AS",
     "qs_pg:gn_country":"AS",
@@ -78,7 +90,7 @@
         }
     ],
     "wof:id":1125830299,
-    "wof:lastmodified":1566588588,
+    "wof:lastmodified":1690850824,
     "wof:name":"`Aoa",
     "wof:parent_id":85668127,
     "wof:placetype":"locality",

--- a/data/112/585/224/1/1125852241.geojson
+++ b/data/112/585/224/1/1125852241.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:azb_x_preferred":[
+        "\u0622\u0644\u0648"
+    ],
     "name:ceb_x_preferred":[
         "Alao"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":1125852241,
-    "wof:lastmodified":1566588588,
+    "wof:lastmodified":1690850824,
     "wof:name":"Alao",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/589/606/9/1125896069.geojson
+++ b/data/112/589/606/9/1125896069.geojson
@@ -43,6 +43,9 @@
     "name:eng_x_preferred":[
         "Fagatogo"
     ],
+    "name:epo_x_preferred":[
+        "Fagatogo"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u06af\u0627\u062a\u0648\u06af\u0648"
     ],
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":1125896069,
-    "wof:lastmodified":1566588586,
+    "wof:lastmodified":1690850822,
     "wof:name":"Fagatogo",
     "wof:parent_id":85668127,
     "wof:placetype":"locality",

--- a/data/112/590/410/3/1125904103.geojson
+++ b/data/112/590/410/3/1125904103.geojson
@@ -64,6 +64,9 @@
     "name:rus_x_preferred":[
         "\u0422\u0430\u0444\u0443\u043d\u0430"
     ],
+    "name:spa_x_preferred":[
+        "Tafuna"
+    ],
     "name:swe_x_preferred":[
         "T\u0101funa"
     ],
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":1125904103,
-    "wof:lastmodified":1566588587,
+    "wof:lastmodified":1690850823,
     "wof:name":"T\u0101funa",
     "wof:parent_id":85668139,
     "wof:placetype":"locality",

--- a/data/112/591/393/3/1125913933.geojson
+++ b/data/112/591/393/3/1125913933.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:azb_x_preferred":[
+        "\u0622\u0644\u0648\u0641\u0627\u0648"
+    ],
     "name:ceb_x_preferred":[
         "Alofau"
     ],
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":1125913933,
-    "wof:lastmodified":1566588587,
+    "wof:lastmodified":1690850823,
     "wof:name":"Alofau",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/592/947/1/1125929471.geojson
+++ b/data/112/592/947/1/1125929471.geojson
@@ -43,6 +43,9 @@
     "name:pol_x_preferred":[
         "Leone"
     ],
+    "name:spa_x_preferred":[
+        "Leone"
+    ],
     "name:swe_x_preferred":[
         "Leone"
     ],
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":1125929471,
-    "wof:lastmodified":1566588585,
+    "wof:lastmodified":1690850822,
     "wof:name":"Leone",
     "wof:parent_id":85668139,
     "wof:placetype":"locality",

--- a/data/112/596/645/5/1125966455.geojson
+++ b/data/112/596/645/5/1125966455.geojson
@@ -22,8 +22,14 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:azb_x_preferred":[
+        "\u062a\u0627\u0648\u0644\u0627\u0642\u0627"
+    ],
     "name:eng_x_preferred":[
         "Taulaga"
+    ],
+    "name:fas_x_preferred":[
+        "\u062a\u0627\u0648\u0644\u0627\u06af\u0627"
     ],
     "name:nld_x_preferred":[
         "Taulaga"
@@ -64,7 +70,7 @@
         }
     ],
     "wof:id":1125966455,
-    "wof:lastmodified":1566588587,
+    "wof:lastmodified":1690850823,
     "wof:name":"Taulaga",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/601/916/5/1126019165.geojson
+++ b/data/112/601/916/5/1126019165.geojson
@@ -28,14 +28,23 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u063a\u0648 \u0628\u0627\u063a\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u062c\u0648 \u0628\u0627\u062c\u0648"
+    ],
     "name:ast_x_preferred":[
         "Pago Pagu"
+    ],
+    "name:azb_x_preferred":[
+        "\u067e\u0627\u0642\u0648 \u067e\u0627\u0642\u0648"
     ],
     "name:aze_x_preferred":[
         "Paqo Paqo"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u0430\u0433\u0430-\u041f\u0430\u0433\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041f\u0430\u0433\u0430-\u041f\u0430\u0433\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09aa\u09be\u0997\u09cb\u09aa\u09be\u0997\u09cb"
@@ -103,6 +112,9 @@
     "name:gla_x_preferred":[
         "Pago Pago"
     ],
+    "name:gle_x_preferred":[
+        "Pago Pago"
+    ],
     "name:glg_x_preferred":[
         "Pago Pago"
     ],
@@ -151,6 +163,9 @@
     "name:kor_x_preferred":[
         "\ud30c\uace0\ud30c\uace0"
     ],
+    "name:kor_x_variant":[
+        "\ud321\uc624\ud321\uc624"
+    ],
     "name:lat_x_preferred":[
         "Pagopago"
     ],
@@ -196,6 +211,9 @@
     "name:por_x_preferred":[
         "Pago Pago"
     ],
+    "name:pus_x_preferred":[
+        "\u067e\u0627\u06ab\u0648 \u067e\u0627\u06ab\u0648"
+    ],
     "name:ron_x_preferred":[
         "Pago Pago"
     ],
@@ -229,6 +247,9 @@
     "name:sqi_x_preferred":[
         "Pago Pago"
     ],
+    "name:srd_x_preferred":[
+        "Pago Pago"
+    ],
     "name:srp_x_preferred":[
         "\u041f\u0430\u0433\u043e \u041f\u0430\u0433\u043e"
     ],
@@ -240,6 +261,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c2a\u0c3e\u0c17\u0c4b \u0c2a\u0c3e\u0c17\u0c4b"
+    ],
+    "name:tgk_x_preferred":[
+        "\u041f\u0430\u0433\u043e-\u041f\u0430\u0433\u043e"
     ],
     "name:tgl_x_preferred":[
         "Pago Pago"
@@ -267,6 +291,9 @@
     ],
     "name:war_x_preferred":[
         "Pago Pago"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5e15\u679c\u5e15\u679c"
     ],
     "name:yue_x_preferred":[
         "\u5e15\u679c\u5e15\u679c"
@@ -312,7 +339,7 @@
         }
     ],
     "wof:id":1126019165,
-    "wof:lastmodified":1566588588,
+    "wof:lastmodified":1690850823,
     "wof:name":"Pago Pago",
     "wof:parent_id":85668127,
     "wof:placetype":"locality",

--- a/data/856/681/33/85668133.geojson
+++ b/data/856/681/33/85668133.geojson
@@ -35,6 +35,9 @@
     "name:deu_x_preferred":[
         "Rose-Atoll"
     ],
+    "name:ell_x_preferred":[
+        "\u0391\u03c4\u03cc\u03bb\u03b7 \u03a1\u03cc\u03bf\u03c5\u03b6"
+    ],
     "name:eng_x_preferred":[
         "Rose Atoll"
     ],
@@ -63,6 +66,9 @@
     "name:kat_x_preferred":[
         "\u10e0\u10dd\u10d6\u10d4"
     ],
+    "name:kor_x_preferred":[
+        "\ub85c\uc988 \ud658\ucd08"
+    ],
     "name:lit_x_preferred":[
         "Rozos atolas"
     ],
@@ -78,8 +84,20 @@
     "name:rus_x_preferred":[
         "\u0420\u043e\u0437\u0435"
     ],
+    "name:smo_x_preferred":[
+        "Rose Motu"
+    ],
+    "name:srp_x_preferred":[
+        "\u0410\u0442\u043e\u043b \u0420\u043e\u0441\u0435"
+    ],
     "name:swe_x_preferred":[
         "Roseatollen"
+    ],
+    "name:tgl_x_preferred":[
+        "Atol ng Rose"
+    ],
+    "name:tur_x_preferred":[
+        "Rose Atolu"
     ],
     "name:urd_x_preferred":[
         "\u0631\u0648\u0632 \u0627\u06cc\u0679\u0648\u0644"
@@ -89,6 +107,9 @@
     ],
     "name:vie_x_preferred":[
         "\u0110\u1ea3o san h\u00f4 Rose"
+    ],
+    "name:vie_x_variant":[
+        "Rose Atoll"
     ],
     "name:zho_cn_x_preferred":[
         "\u7f57\u65af\u73af\u7901"
@@ -194,7 +215,7 @@
         "wof:belongsto"
     ],
     "wof:country":"AS",
-    "wof:geomhash":"72938f4f09e4730482e4a56cf51565ee",
+    "wof:geomhash":"c4b99ff6f7acf790e0fb977551e51cc0",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -212,7 +233,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1684438875,
+    "wof:lastmodified":1690850822,
     "wof:name":"Rose Atoll",
     "wof:parent_id":85632697,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.