### PR TITLE
as concordances, placetype local, and more

### DIFF
--- a/data/856/681/27/85668127.geojson
+++ b/data/856/681/27/85668127.geojson
@@ -170,6 +170,7 @@
         "qs_pg:id":1263411,
         "uscensus:geoid":"60010"
     },
+    "wof:concordances_official":"uscensus:geoid",
     "wof:country":"AS",
     "wof:geom_alt":[
         "uscensus-display-terrestrial-zoom-10"
@@ -193,7 +194,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1684438875,
+    "wof:lastmodified":1695885335,
     "wof:name":"Eastern",
     "wof:parent_id":85632697,
     "wof:placetype":"region",

--- a/data/856/681/31/85668131.geojson
+++ b/data/856/681/31/85668131.geojson
@@ -192,6 +192,7 @@
         "qs_pg:id":959566,
         "uscensus:geoid":"60020"
     },
+    "wof:concordances_official":"uscensus:geoid",
     "wof:country":"AS",
     "wof:geomhash":"9b5ff75b17e1a9c274eb998271bd48f3",
     "wof:hierarchy":[
@@ -212,7 +213,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1684438875,
+    "wof:lastmodified":1695885335,
     "wof:name":"Manu's",
     "wof:parent_id":85632697,
     "wof:placetype":"region",

--- a/data/856/681/33/85668133.geojson
+++ b/data/856/681/33/85668133.geojson
@@ -212,6 +212,7 @@
         "uscensus:geoid":"60030",
         "wd:id":"Q1636779"
     },
+    "wof:concordances_official":"uscensus:geoid",
     "wof:controlled":[
         "wof:hierarchy",
         "wof:parent_id",
@@ -236,7 +237,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1694493129,
+    "wof:lastmodified":1695884323,
     "wof:name":"Rose Atoll",
     "wof:parent_id":85632697,
     "wof:placetype":"region",

--- a/data/856/681/37/85668137.geojson
+++ b/data/856/681/37/85668137.geojson
@@ -194,6 +194,7 @@
         "qs_pg:id":352431,
         "uscensus:geoid":"60040"
     },
+    "wof:concordances_official":"uscensus:geoid",
     "wof:country":"AS",
     "wof:geomhash":"feec09f0f79667666ba9e8e134a7d422",
     "wof:hierarchy":[
@@ -212,7 +213,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1684438875,
+    "wof:lastmodified":1695885335,
     "wof:name":"Swain's Island",
     "wof:parent_id":85632697,
     "wof:placetype":"region",

--- a/data/856/681/39/85668139.geojson
+++ b/data/856/681/39/85668139.geojson
@@ -195,6 +195,7 @@
         "qs_pg:id":114034,
         "uscensus:geoid":"60050"
     },
+    "wof:concordances_official":"uscensus:geoid",
     "wof:country":"AS",
     "wof:geomhash":"a4bc0ae88d5cdfab405d6ba2da603f67",
     "wof:hierarchy":[
@@ -215,7 +216,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1684438875,
+    "wof:lastmodified":1695885335,
     "wof:name":"Western",
     "wof:parent_id":85632697,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.